### PR TITLE
Add Google repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 


### PR DESCRIPTION
Hello,

I get this error when I try to build the app for F-Droid:
```
Execution failed for task ':app:lintVitalRelease'.
> Could not resolve all files for configuration ':app:lintClassPath'.
   > Could not find com.android.tools.lint:lint-gradle:26.1.3.
     Searched in the following locations:
         file:/home/pierre/www/android-sdk/extras/m2repository/com/android/tools/lint/lint-gradle/26.1.3/lint-gradle-26.1.3.pom
         file:/home/pierre/www/android-sdk/extras/m2repository/com/android/tools/lint/lint-gradle/26.1.3/lint-gradle-26.1.3.jar
         file:/home/pierre/www/android-sdk/extras/google/m2repository/com/android/tools/lint/lint-gradle/26.1.3/lint-gradle-26.1.3.pom
         file:/home/pierre/www/android-sdk/extras/google/m2repository/com/android/tools/lint/lint-gradle/26.1.3/lint-gradle-26.1.3.jar
         file:/home/pierre/www/android-sdk/extras/android/m2repository/com/android/tools/lint/lint-gradle/26.1.3/lint-gradle-26.1.3.pom
         file:/home/pierre/www/android-sdk/extras/android/m2repository/com/android/tools/lint/lint-gradle/26.1.3/lint-gradle-26.1.3.jar
         https://jcenter.bintray.com/com/android/tools/lint/lint-gradle/26.1.3/lint-gradle-26.1.3.pom
         https://jcenter.bintray.com/com/android/tools/lint/lint-gradle/26.1.3/lint-gradle-26.1.3.jar
     Required by:
         project :app
```

I think the Google repository is added automatically by Android Studio but not by Gradle.

This patch fixes the error.